### PR TITLE
feat: add admin domain entities (Activity, Project, ProjectMember, Di…

### DIFF
--- a/src/main/java/com/gdgoc/arcive/domain/activity/entity/Activity.java
+++ b/src/main/java/com/gdgoc/arcive/domain/activity/entity/Activity.java
@@ -1,0 +1,35 @@
+package com.gdgoc.arcive.domain.activity.entity;
+
+import com.gdgoc.arcive.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Activity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "activity_id")
+    private Long id;
+
+    @Column(nullable = false, length = 255)
+    private String name;
+
+    @Column(nullable = false, length = 255)
+    private String title;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String description;
+
+    @Column(name = "image_url", nullable = false, length = 255)
+    private String imageUrl;
+}
+

--- a/src/main/java/com/gdgoc/arcive/domain/activity/repository/ActivityRepository.java
+++ b/src/main/java/com/gdgoc/arcive/domain/activity/repository/ActivityRepository.java
@@ -1,0 +1,9 @@
+package com.gdgoc.arcive.domain.activity.repository;
+
+import com.gdgoc.arcive.domain.activity.entity.Activity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ActivityRepository extends JpaRepository<Activity, Long> {
+
+}
+

--- a/src/main/java/com/gdgoc/arcive/domain/notification/entity/DiscordNotificationLog.java
+++ b/src/main/java/com/gdgoc/arcive/domain/notification/entity/DiscordNotificationLog.java
@@ -1,0 +1,46 @@
+package com.gdgoc.arcive.domain.notification.entity;
+
+import com.gdgoc.arcive.domain.member.entity.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.EntityListeners;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DiscordNotificationLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "log_id")
+    private Long id;
+
+    @Column(name = "event_type", nullable = false, length = 50)
+    private String eventType;
+
+    @Column(name = "is_success", nullable = false)
+    private boolean isSuccess;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+}
+

--- a/src/main/java/com/gdgoc/arcive/domain/notification/repository/DiscordNotificationLogRepository.java
+++ b/src/main/java/com/gdgoc/arcive/domain/notification/repository/DiscordNotificationLogRepository.java
@@ -1,0 +1,9 @@
+package com.gdgoc.arcive.domain.notification.repository;
+
+import com.gdgoc.arcive.domain.notification.entity.DiscordNotificationLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DiscordNotificationLogRepository extends JpaRepository<DiscordNotificationLog, Long> {
+
+}
+

--- a/src/main/java/com/gdgoc/arcive/domain/project/entity/Project.java
+++ b/src/main/java/com/gdgoc/arcive/domain/project/entity/Project.java
@@ -1,0 +1,43 @@
+package com.gdgoc.arcive.domain.project.entity;
+
+import com.gdgoc.arcive.domain.activity.entity.Activity;
+import com.gdgoc.arcive.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Project extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "project_id")
+    private Long id;
+
+    @Column(name = "project_name", nullable = false, length = 100)
+    private String projectName;
+
+    @Column(nullable = false)
+    private int generation;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String description;
+
+    @Column(name = "image_url", length = 255)
+    private String imageUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "activity_id", nullable = false)
+    private Activity activity;
+}
+

--- a/src/main/java/com/gdgoc/arcive/domain/project/entity/ProjectMember.java
+++ b/src/main/java/com/gdgoc/arcive/domain/project/entity/ProjectMember.java
@@ -1,0 +1,37 @@
+package com.gdgoc.arcive.domain.project.entity;
+
+import com.gdgoc.arcive.domain.member.entity.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@IdClass(ProjectMemberId.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProjectMember {
+
+    @Id
+    @Column(name = "project_id")
+    private Long projectId;
+
+    @Id
+    @Column(name = "member_id")
+    private Long memberId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id", insertable = false, updatable = false)
+    private Project project;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", insertable = false, updatable = false)
+    private Member member;
+}
+

--- a/src/main/java/com/gdgoc/arcive/domain/project/entity/ProjectMemberId.java
+++ b/src/main/java/com/gdgoc/arcive/domain/project/entity/ProjectMemberId.java
@@ -1,0 +1,31 @@
+package com.gdgoc.arcive.domain.project.entity;
+
+import java.io.Serializable;
+import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProjectMemberId implements Serializable {
+
+    private Long projectId;
+    private Long memberId;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ProjectMemberId that = (ProjectMemberId) o;
+        return Objects.equals(projectId, that.projectId) &&
+                Objects.equals(memberId, that.memberId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(projectId, memberId);
+    }
+}
+

--- a/src/main/java/com/gdgoc/arcive/domain/project/repository/ProjectMemberRepository.java
+++ b/src/main/java/com/gdgoc/arcive/domain/project/repository/ProjectMemberRepository.java
@@ -1,0 +1,10 @@
+package com.gdgoc.arcive.domain.project.repository;
+
+import com.gdgoc.arcive.domain.project.entity.ProjectMember;
+import com.gdgoc.arcive.domain.project.entity.ProjectMemberId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectMemberRepository extends JpaRepository<ProjectMember, ProjectMemberId> {
+
+}
+

--- a/src/main/java/com/gdgoc/arcive/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/com/gdgoc/arcive/domain/project/repository/ProjectRepository.java
@@ -1,0 +1,9 @@
+package com.gdgoc.arcive.domain.project.repository;
+
+import com.gdgoc.arcive.domain.project.entity.Project;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+
+}
+


### PR DESCRIPTION
…scordNotificationLog)

## #️⃣ 연관된 이슈

> Admin 도메인 엔티티 구현 관련 이슈

## 💡 작업 내용

### 추가된 엔티티
- **Activity** (활동): 활동 정보를 관리하는 엔티티
  - `activity_id`, `name`, `title`, `description`, `image_url`, `created_at`, `updated_at`
  
- **Project** (프로젝트): 프로젝트 정보를 관리하는 엔티티
  - `project_id`, `project_name`, `generation`, `description`, `image_url`, `activity_id`, `created_at`, `updated_at`
  - Activity와 Many-to-One 관계로 연결

- **ProjectMember** (프로젝트 참여자): 프로젝트와 멤버의 중간 테이블
  - 복합키: `project_id`, `member_id`
  - Project와 Member를 연결

- **DiscordNotificationLog** (디스코드 알림 로그): 디스코드 알림 전송 로그를 관리하는 엔티티
  - `log_id`, `event_type`, `is_success`, `created_at`, `member_id`
  - Member와 Many-to-One 관계로 연결

### 추가된 Repository
- `ActivityRepository`
- `ProjectRepository`
- `ProjectMemberRepository` (복합키 사용)
- `DiscordNotificationLogRepository`