### PR TITLE
feat: 전공 필드를 enum에서 String으로 변경

### DIFF
--- a/src/main/java/com/gdgoc/arcive/domain/member/dto/MemberOnboardingRequest.java
+++ b/src/main/java/com/gdgoc/arcive/domain/member/dto/MemberOnboardingRequest.java
@@ -1,6 +1,5 @@
 package com.gdgoc.arcive.domain.member.dto;
 
-import com.gdgoc.arcive.domain.member.entity.Major;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,6 +8,6 @@ import lombok.NoArgsConstructor;
 public class MemberOnboardingRequest {
     private String name;
     private String studentId;
-    private Major major;
+    private String major;
     private Integer generation;
 }

--- a/src/main/java/com/gdgoc/arcive/domain/member/entity/MemberProfile.java
+++ b/src/main/java/com/gdgoc/arcive/domain/member/entity/MemberProfile.java
@@ -21,9 +21,8 @@ public class MemberProfile {
     @Column(nullable = false, length = 100)
     private String name;
 
-    @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 100)
-    private Major major;
+    private String major;
 
     @Column(nullable = false)
     private int generation;
@@ -38,7 +37,7 @@ public class MemberProfile {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    public void updateOnboardingInfo(String name, String studentId, Major major, int generation) {
+    public void updateOnboardingInfo(String name, String studentId, String major, int generation) {
         this.name = name;
         this.studentId = studentId;
         this.major = major;

--- a/src/main/java/com/gdgoc/arcive/domain/member/service/MemberService.java
+++ b/src/main/java/com/gdgoc/arcive/domain/member/service/MemberService.java
@@ -96,7 +96,7 @@ public class MemberService {
                 .name(profile.getName())
                 .email(member.getEmail())
                 .studentId(profile.getStudentId())
-                .major(profile.getMajor().name())
+                .major(profile.getMajor())
                 .generation(profile.getGeneration())
                 .bio(profile.getBio())
                 .profileImageUrl(profile.getProfileImageUrl())


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- 학과 enum 관련 이슈


## 💡 작업 내용

- MemberOnboardingRequest의 major 필드를 String으로 변경
- MemberProfile 엔티티의 major 필드를 String으로 변경
- 프론트엔드에서 다양한 학과명을 문자열로 전송할 수 있도록 수정