### PR TITLE
예외 처리 개선 및 Validation 추가

### DIFF
--- a/src/main/java/com/gdgoc/arcive/domain/member/controller/MemberController.java
+++ b/src/main/java/com/gdgoc/arcive/domain/member/controller/MemberController.java
@@ -7,6 +7,7 @@ import com.gdgoc.arcive.domain.member.dto.MemberUpdateRequest;
 import com.gdgoc.arcive.domain.member.service.MemberService;
 import com.gdgoc.arcive.global.security.oauth2.entity.CustomOAuth2User;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -25,7 +26,7 @@ public class MemberController {
     @PostMapping("/me/onboarding")
     public ResponseEntity<Void> onboardMember(
             @AuthenticationPrincipal CustomOAuth2User user,
-            @RequestBody MemberOnboardingRequest request) {
+            @Valid @RequestBody MemberOnboardingRequest request) {
         memberService.onboardMember(user.getId(), request);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/gdgoc/arcive/domain/member/dto/MemberOnboardingRequest.java
+++ b/src/main/java/com/gdgoc/arcive/domain/member/dto/MemberOnboardingRequest.java
@@ -1,13 +1,24 @@
 package com.gdgoc.arcive.domain.member.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 public class MemberOnboardingRequest {
+    @NotBlank(message = "이름은 필수입니다.")
     private String name;
+    
+    @NotBlank(message = "학번은 필수입니다.")
     private String studentId;
+    
+    @NotBlank(message = "전공은 필수입니다.")
     private String major;
+    
+    @NotNull(message = "기수는 필수입니다.")
+    @Positive(message = "기수는 양수여야 합니다.")
     private Integer generation;
 }

--- a/src/main/java/com/gdgoc/arcive/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/gdgoc/arcive/domain/member/exception/MemberErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum MemberErrorCode implements BaseErrorCode {
 
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-001", "존재하지 않는 회원입니다.");
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-001", "존재하지 않는 회원입니다."),
+    PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-002", "존재하지 않는 프로필입니다.");
 
     private final HttpStatus status;
     private final String value;


### PR DESCRIPTION


## #️⃣ 연관된 이슈

예외 처리 개선 및 Validation 추가

## 💡 작업 내용
예외 처리 개선, Validation 추가, 기본 프로필 이미지 URL 설정을 포함한 리팩토링을 진행했습니다.

###주요 수정 사항
1. 예외 처리 개선
- IllegalArgumentException → MemberException으로 변경하여 일관된 예외 처리
- MemberErrorCode에 PROFILE_NOT_FOUND 에러 코드 추가
- 모든 예외를 MemberException으로 통일하여 에러 응답 형식 일관성 확보
2. Validation 추가
- MemberOnboardingRequest에 필수 필드 검증 추가:
- name: @NotBlank - 이름은 필수
- studentId: @NotBlank - 학번은 필수
- major: @NotBlank - 전공은 필수
- generation: @NotNull, @Positive - 기수는 양수 필수
- Controller에 @Valid 어노테이션 추가하여 요청 데이터 검증 활성화
3. 기본 프로필 이미지 URL 설정
- S3 설정(S3Properties)을 주입받아 기본 프로필 이미지 URL 자동 설정
- - urlPrefix + defaultFemaleProfileImage 조합으로 완전한 URL 생성
- S3 설정이 없을 경우 빈 문자열로 안전하게 처리
🔧 주요 변경사항
수정 파일
- MemberOnboardingRequest.java - 필수 필드 validation 추가
- MemberService.java - MemberException 사용, S3Properties 주입, 기본 프로필 이미지 URL 설정 로직 추가
- MemberController.java - @Valid 어노테이션 추가
- MemberErrorCode.java - PROFILE_NOT_FOUND 에러 코드 추가